### PR TITLE
accept "0" in Secp256k1Scalar::from

### DIFF
--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -129,6 +129,10 @@ impl ECScalar<SK> for Secp256k1Scalar {
     }
 
     fn from(n: &BigInt) -> Secp256k1Scalar {
+        if n.eq(&BigInt::zero()) {
+            return Self::zero();
+        }
+
         let curve_order = FE::q();
         let n_reduced = BigInt::mod_add(n, &BigInt::from(0), &curve_order);
         let mut v = BigInt::to_vec(&n_reduced);
@@ -648,10 +652,13 @@ mod tests {
     #[test]
     fn deserialize_sk() {
         let s = "\"1e240\"";
-        let dummy: Secp256k1Scalar = serde_json::from_str(s).expect("Failed in serialization");
-
+        let dummy: Secp256k1Scalar = serde_json::from_str(s).expect("Failed in deserialization");
         let sk: Secp256k1Scalar = ECScalar::from(&BigInt::from(123456));
+        assert_eq!(dummy, sk);
 
+        let s = "\"0\"";
+        let dummy: Secp256k1Scalar = serde_json::from_str(s).expect("Failed in deserialization");
+        let sk: Secp256k1Scalar = ECScalar::zero();
         assert_eq!(dummy, sk);
     }
 


### PR DESCRIPTION
"0" is a valid input. 
Previously, `ECScalar::from(&BigInt::from("0"))` has panicked. 
This PR returns `ECScalar::zero()` in such case.

Motivation for this change:
In https://github.com/KZen-networks/centipede the struct `Witness` is defined:
```
pub struct Witness {
    pub x_vec: Vec<FE>,
    pub r_vec: Vec<FE>,
}
```
where `x_vec` is a vector of octets, often containing '0'. Therefore, the deserialization of the serialization of such instance of the struct, panics. 