### PR TITLE
Efficient computation of product of pairings

### DIFF
--- a/src/elliptic/curves/bls12_381/g1.rs
+++ b/src/elliptic/curves/bls12_381/g1.rs
@@ -28,7 +28,7 @@ use serde::ser::SerializeStruct;
 use serde::ser::{Serialize, Serializer};
 use serde::{Deserialize, Deserializer};
 use std::fmt;
-use std::ops::{Add, Mul};
+use std::ops::{Add, Mul, Neg};
 pub type SK = <pairing_plus::bls12_381::Bls12 as ScalarEngine>::Fr;
 pub type PK = <pairing_plus::bls12_381::Bls12 as Engine>::G1Affine;
 
@@ -437,6 +437,15 @@ impl<'o> Add<&'o G1Point> for &'o G1Point {
     type Output = G1Point;
     fn add(self, other: &'o G1Point) -> G1Point {
         self.add_point(&other.get_element())
+    }
+}
+
+impl Neg for G1Point {
+    type Output = Self;
+    fn neg(mut self) -> Self {
+        self.ge.negate();
+        self.purpose = "negated";
+        self
     }
 }
 

--- a/src/elliptic/curves/bls12_381/g2.rs
+++ b/src/elliptic/curves/bls12_381/g2.rs
@@ -29,7 +29,7 @@ use serde::ser::SerializeStruct;
 use serde::ser::{Serialize, Serializer};
 use serde::{Deserialize, Deserializer};
 use std::fmt;
-use std::ops::{Add, Mul};
+use std::ops::{Add, Mul, Neg};
 pub type SK = <pairing_plus::bls12_381::Bls12 as ScalarEngine>::Fr;
 pub type PK = <pairing_plus::bls12_381::Bls12 as Engine>::G2Affine;
 
@@ -439,6 +439,15 @@ impl<'o> Add<&'o G2Point> for &'o G2Point {
     type Output = G2Point;
     fn add(self, other: &'o G2Point) -> G2Point {
         self.add_point(&other.get_element())
+    }
+}
+
+impl Neg for G2Point {
+    type Output = Self;
+    fn neg(mut self) -> Self {
+        self.ge.negate();
+        self.purpose = "negated";
+        self
     }
 }
 


### PR DESCRIPTION
PR adds method for efficient computation of product of pairings with single final exponentiation. Also trait `Neg` is implemented for both bls12_381::{g1,g2}::GE. Eventually there should be method `.negate()` as part of `ECPoint` trait, but it's tricky.