### PR TITLE
Implement From trait for BLS g1 & g2 points

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curv"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2018"
 authors = ["Omer Shlomovits"]
 license = "MIT"

--- a/src/cryptographic_primitives/commitments/hash_commitment.rs
+++ b/src/cryptographic_primitives/commitments/hash_commitment.rs
@@ -80,7 +80,7 @@ mod tests {
         let (_commitment, blind_factor) = HashCommitment::create_commitment(&message);
         let commitment2 =
             HashCommitment::create_commitment_with_user_defined_randomness(&message, &blind_factor);
-        assert_eq!(commitment2.to_str_radix(16).len(), SECURITY_BITS / 4);
+        assert!(commitment2.to_str_radix(16).len() / 2 <= SECURITY_BITS / 8);
     }
 
     #[test]

--- a/src/elliptic/curves/bls12_381/g1.rs
+++ b/src/elliptic/curves/bls12_381/g1.rs
@@ -403,6 +403,15 @@ impl ECPoint for G1Point {
     }
 }
 
+impl From<pairing_plus::bls12_381::G1Affine> for G1Point {
+    fn from(point: PK) -> Self {
+        G1Point {
+            purpose: "from_point",
+            ge: point,
+        }
+    }
+}
+
 impl Mul<FieldScalar> for G1Point {
     type Output = G1Point;
     fn mul(self, other: FieldScalar) -> G1Point {

--- a/src/elliptic/curves/bls12_381/g2.rs
+++ b/src/elliptic/curves/bls12_381/g2.rs
@@ -413,6 +413,15 @@ impl ECPoint for G2Point {
     }
 }
 
+impl From<pairing_plus::bls12_381::G2Affine> for G2Point {
+    fn from(point: PK) -> Self {
+        G2Point {
+            purpose: "from_point",
+            ge: point,
+        }
+    }
+}
+
 impl Mul<FieldScalar> for G2Point {
     type Output = G2Point;
     fn mul(self, other: FieldScalar) -> G2Point {


### PR DESCRIPTION
PR allows constructing BLS point from underlying structure (either G1Affine or G2Affine). 

It also worth to consider adding this method to ECPoint trait: 
```rust
fn from_element(Self::PublicKey) -> Self
```

There's similar method in ECScalar trait: `set_element`.