### PR TITLE
Improve BigInt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curv"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2018"
 authors = ["Omer Shlomovits"]
 license = "MIT"

--- a/src/arithmetic/big_gmp.rs
+++ b/src/arithmetic/big_gmp.rs
@@ -151,6 +151,7 @@ impl Primes for BigInt {
 
 impl Modulo for BigInt {
     fn mod_pow(base: &Self, exponent: &Self, modulus: &Self) -> Self {
+        assert!(exponent >= &BigInt::zero(), "exponent must be non-negative");
         base.gmp.powm(&exponent.gmp, &modulus.gmp).wrap()
     }
 

--- a/src/arithmetic/big_gmp.rs
+++ b/src/arithmetic/big_gmp.rs
@@ -325,15 +325,20 @@ crate::__bigint_impl_ops! {
 
 crate::__bigint_impl_assigns! {
     AddAssign add_assign,
+    AddAssign add_assign u64,
     BitAndAssign bitand_assign,
     BitOrAssign bitor_assign,
     BitXorAssign bitxor_assign,
     DivAssign div_assign,
+    DivAssign div_assign u64,
     MulAssign mul_assign,
+    MulAssign mul_assign u64,
     RemAssign rem_assign,
+    RemAssign rem_assign u64,
     ShlAssign shl_assign usize,
     ShrAssign shr_assign usize,
     SubAssign sub_assign,
+    SubAssign sub_assign u64,
 }
 
 impl ops::Neg for BigInt {

--- a/src/arithmetic/big_native.rs
+++ b/src/arithmetic/big_native.rs
@@ -74,18 +74,26 @@ impl Converter for BigInt {
                 radix: 16,
             })
     }
-}
 
-impl Num for BigInt {
-    type FromStrRadixErr = ParseBigIntError;
+    fn to_str_radix(&self, radix: u8) -> String {
+        self.num.to_str_radix(radix.into())
+    }
 
-    fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
-        BN::parse_bytes(str.as_bytes(), radix)
+    fn from_str_radix(str: &str, radix: u8) -> Result<Self, ParseBigIntError> {
+        BN::parse_bytes(str.as_bytes(), radix.into())
             .map(Wrap::wrap)
             .ok_or(ParseBigIntError {
                 reason: ParseErrorReason::NumBigint,
-                radix,
+                radix: radix.into(),
             })
+    }
+}
+
+impl num_traits::Num for BigInt {
+    type FromStrRadixErr = ParseBigIntError;
+
+    fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        <Self as Converter>::from_str_radix(str, radix.try_into().unwrap())
     }
 }
 
@@ -310,9 +318,9 @@ crate::__bigint_impl_ops! {
     Shl shl usize,
     Shr shr usize,
 
-    Add add u64,
-    Sub sub u64,
-    Mul mul u64,
+    Add add u64 [swap],
+    Sub sub u64 [swap],
+    Mul mul u64 [swap],
     Div div u64,
     Rem rem u64,
 }

--- a/src/arithmetic/big_native.rs
+++ b/src/arithmetic/big_native.rs
@@ -327,15 +327,20 @@ crate::__bigint_impl_ops! {
 
 crate::__bigint_impl_assigns! {
     AddAssign add_assign,
+    AddAssign add_assign u64,
     BitAndAssign bitand_assign,
     BitOrAssign bitor_assign,
     BitXorAssign bitxor_assign,
     DivAssign div_assign,
+    DivAssign div_assign u64,
     MulAssign mul_assign,
+    MulAssign mul_assign u64,
     RemAssign rem_assign,
+    RemAssign rem_assign u64,
     ShlAssign shl_assign usize,
     ShrAssign shr_assign usize,
     SubAssign sub_assign,
+    SubAssign sub_assign u64,
 }
 
 impl ops::Neg for BigInt {

--- a/src/arithmetic/macros.rs
+++ b/src/arithmetic/macros.rs
@@ -58,6 +58,33 @@ macro_rules! __bigint_impl_ops {
         }
         $crate::__bigint_impl_ops!{ $($rest)* }
     };
+    ($op: ident $func:ident $primitive:ty [swap], $($rest:tt)*) => {
+        impl ops::$op<$primitive> for BigInt {
+            type Output = BigInt;
+            fn $func(self, rhs: $primitive) -> Self::Output {
+                self.into_inner().$func(rhs).wrap()
+            }
+        }
+        impl ops::$op<$primitive> for &BigInt {
+            type Output = BigInt;
+            fn $func(self, rhs: $primitive) -> Self::Output {
+                (&self.inner_ref()).$func(rhs).wrap()
+            }
+        }
+        impl ops::$op<BigInt> for $primitive {
+            type Output = BigInt;
+            fn $func(self, rhs: BigInt) -> Self::Output {
+                self.$func(rhs.into_inner()).wrap()
+            }
+        }
+        impl ops::$op<&BigInt> for $primitive {
+            type Output = BigInt;
+            fn $func(self, rhs: &BigInt) -> Self::Output {
+                self.$func(rhs.inner_ref()).wrap()
+            }
+        }
+        $crate::__bigint_impl_ops!{ $($rest)* }
+    };
 }
 
 #[doc(hidden)]

--- a/src/arithmetic/mod.rs
+++ b/src/arithmetic/mod.rs
@@ -264,6 +264,12 @@ mod test {
         assert_eq!(one, BigInt::one());
     }
 
+    #[test]
+    #[should_panic]
+    fn mod_pow_panics_if_exp_is_negative() {
+        BigInt::mod_pow(&BigInt::from(3), &(-BigInt::one()), &BigInt::from(7));
+    }
+
     const PRIMES: &[&str] = &[
         "2",
         "3",

--- a/src/arithmetic/mod.rs
+++ b/src/arithmetic/mod.rs
@@ -401,6 +401,7 @@ mod test {
         // Assigns traits
         for<'a> BigInt: AddAssign
             + AddAssign<&'a BigInt>
+            + AddAssign<u64>
             + BitAndAssign
             + BitAndAssign<&'a BigInt>
             + BitOrAssign
@@ -409,12 +410,16 @@ mod test {
             + BitXorAssign<&'a BigInt>
             + DivAssign
             + DivAssign<&'a BigInt>
+            + DivAssign<u64>
             + MulAssign
             + MulAssign<&'a BigInt>
+            + MulAssign<u64>
             + RemAssign
             + RemAssign<&'a BigInt>
+            + RemAssign<u64>
             + SubAssign
-            + SubAssign<&'a BigInt>,
+            + SubAssign<&'a BigInt>
+            + SubAssign<u64>,
     {
     }
 }

--- a/src/arithmetic/mod.rs
+++ b/src/arithmetic/mod.rs
@@ -385,11 +385,19 @@ mod test {
         BigInt: Add<u64, Output = BigInt>
             + Sub<u64, Output = BigInt>
             + Mul<u64, Output = BigInt>
-            + Div<u64, Output = BigInt>,
+            + Div<u64, Output = BigInt>
+            + Rem<u64, Output = BigInt>,
         for<'a> &'a BigInt: Add<u64, Output = BigInt>
             + Sub<u64, Output = BigInt>
             + Mul<u64, Output = BigInt>
-            + Div<u64, Output = BigInt>,
+            + Div<u64, Output = BigInt>
+            + Rem<u64, Output = BigInt>,
+        u64: Add<BigInt, Output = BigInt>
+            + Sub<BigInt, Output = BigInt>
+            + Mul<BigInt, Output = BigInt>,
+        for<'a> u64: Add<&'a BigInt, Output = BigInt>
+            + Sub<&'a BigInt, Output = BigInt>
+            + Mul<&'a BigInt, Output = BigInt>,
         // Assigns traits
         for<'a> BigInt: AddAssign
             + AddAssign<&'a BigInt>

--- a/src/arithmetic/traits.rs
+++ b/src/arithmetic/traits.rs
@@ -117,12 +117,19 @@ pub trait BasicOps {
 
 /// Modular arithmetic for BigInt
 pub trait Modulo: Sized {
-    fn mod_pow(base: &Self, exponent: &Self, modulus: &Self) -> Self;
+    /// Calculates base^(exponent) (mod m)
+    ///
+    /// Exponent must not be negative. Function will panic otherwise.
+    fn mod_pow(base: &Self, exponent: &Self, m: &Self) -> Self;
+    /// Calculates a * b (mod m)
     fn mod_mul(a: &Self, b: &Self, modulus: &Self) -> Self;
+    /// Calculates a - b (mod m)
     fn mod_sub(a: &Self, b: &Self, modulus: &Self) -> Self;
+    /// Calculates a + b (mod m)
     fn mod_add(a: &Self, b: &Self, modulus: &Self) -> Self;
-    /// Returns b = a^-1 (mod m). Returns None if `a` and `m` are not coprimes.
+    /// Calculates a^-1 (mod m). Returns None if `a` and `m` are not coprimes.
     fn mod_inv(a: &Self, m: &Self) -> Option<Self>;
+    /// Calculates a mod m
     fn modulus(&self, modulus: &Self) -> Self;
 }
 

--- a/src/arithmetic/traits.rs
+++ b/src/arithmetic/traits.rs
@@ -19,7 +19,7 @@ use super::errors::ParseBigIntError;
 /// Reuse common traits from [num_integer] crate
 pub use num_integer::{Integer, Roots};
 /// Reuse common traits from [num_traits] crate
-pub use num_traits::{Num, One, Zero};
+pub use num_traits::{One, Zero};
 
 #[deprecated(
     since = "0.6.0",
@@ -47,6 +47,7 @@ pub trait Converter: Sized {
     /// assert_eq!(BigInt::from_bytes(&[15, 66, 64]), BigInt::from(1_000_000))
     /// ```
     fn from_bytes(bytes: &[u8]) -> Self;
+
     /// Converts BigInt to hex representation.
     ///
     /// If the number is negative, it will be serialized by absolute value, and minus character
@@ -58,7 +59,9 @@ pub trait Converter: Sized {
     /// assert_eq!(BigInt::from(31).to_hex(), "1f");
     /// assert_eq!(BigInt::from(1_000_000).to_hex(), "f4240");
     /// ```
-    fn to_hex(&self) -> String;
+    fn to_hex(&self) -> String {
+        self.to_str_radix(16)
+    }
     /// Parses given hex string.
     ///
     /// Follows the same format as was described in [to_hex](Self::to_hex).
@@ -71,7 +74,33 @@ pub trait Converter: Sized {
     /// assert_eq!(BigInt::from_hex("f4240").unwrap(), BigInt::from(1_000_000));
     /// assert_eq!(BigInt::from_hex("-f4240").unwrap(), BigInt::from(-1_000_000));
     /// ```
-    fn from_hex(n: &str) -> Result<Self, ParseBigIntError>;
+    fn from_hex(n: &str) -> Result<Self, ParseBigIntError> {
+        Self::from_str_radix(n, 16)
+    }
+
+    /// Converts BigInt to radix representation.
+    ///
+    /// If the number is negative, it will be serialized by absolute value, and minus character
+    /// will be prepended to resulting string.
+    ///
+    /// ## Examples
+    /// ```
+    /// # use curv::arithmetic::{BigInt, Converter};
+    /// assert_eq!(BigInt::from(31).to_str_radix(16), "1f");
+    /// assert_eq!(BigInt::from(1_000_000).to_str_radix(16), "f4240");
+    /// ```
+    fn to_str_radix(&self, radix: u8) -> String;
+    /// Parses given radix string.
+    ///
+    /// Radix must be in `[2; 36]` range. Otherwise, function will **panic**.
+    ///
+    /// ## Examples
+    /// ```
+    /// # use curv::arithmetic::{BigInt, Converter};
+    /// assert_eq!(BigInt::from_str_radix("1f", 16).unwrap(), BigInt::from(31));
+    /// assert_eq!(BigInt::from_str_radix("f4240", 16).unwrap(), BigInt::from(1_000_000));
+    /// ```
+    fn from_str_radix(s: &str, radix: u8) -> Result<Self, ParseBigIntError>;
 }
 
 /// Provides basic arithmetic operators for BigInt


### PR DESCRIPTION
PR expands set of traits implemented for BigInt (based on my experience of updating upstream crates), and also changes Converter+Modulo traits.

Important change here is that `Modulo::mod_pow` will panic if exponent is negative. Negative exponents should be handled via `mod_inv`.