### PR TITLE
No panic when new_random generates invalid value

### DIFF
--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -27,7 +27,7 @@ use crypto::digest::Digest;
 use crypto::sha3::Sha3;
 #[cfg(feature = "merkle")]
 use merkle::Hashable;
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 use secp256k1::constants::{
     CURVE_ORDER, GENERATOR_X, GENERATOR_Y, SECRET_KEY_SIZE, UNCOMPRESSED_PUBLIC_KEY_SIZE,
 };
@@ -94,21 +94,9 @@ impl ECScalar for Secp256k1Scalar {
     type SecretKey = SK;
 
     fn new_random() -> Secp256k1Scalar {
-        let mut arr = [0u8; 32];
-        let mut rng = thread_rng();
-
-        rng.fill(&mut arr[..]);
-        let mut fe = SK::from_slice(&arr[..]);
-        loop {
-            if let Ok(fe) = fe {
-                return Secp256k1Scalar {
-                    purpose: "random",
-                    fe,
-                };
-            } else {
-                rng.fill(&mut arr[..]);
-                fe = SK::from_slice(&arr[..]);
-            }
+        Secp256k1Scalar {
+            purpose: "random",
+            fe: SecretKey::new(&mut thread_rng()),
         }
     }
 

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -95,10 +95,20 @@ impl ECScalar for Secp256k1Scalar {
 
     fn new_random() -> Secp256k1Scalar {
         let mut arr = [0u8; 32];
-        thread_rng().fill(&mut arr[..]);
-        Secp256k1Scalar {
-            purpose: "random",
-            fe: SK::from_slice(&arr[0..arr.len()]).unwrap(),
+        let mut rng = thread_rng();
+
+        rng.fill(&mut arr[..]);
+        let mut fe = SK::from_slice(&arr[..]);
+        loop {
+            if let Ok(fe) = fe {
+                return Secp256k1Scalar {
+                    purpose: "random",
+                    fe,
+                };
+            } else {
+                rng.fill(&mut arr[..]);
+                fe = SK::from_slice(&arr[..]);
+            }
         }
     }
 


### PR DESCRIPTION
This PR prevents the crate from panic by randomize another key when the previously generated one is invalid, though it's very unlikely to happen.