### PR TITLE
curv2: fix subtraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.8.0-rc3
+* Fix point subtraction. Bug was introduced in `v0.8.0-rc1`. [#127]
+
+[#127]: https://github.com/ZenGo-X/curv/pull/127
+
 ## v0.8.0-rc2
 * Remove dependency on `ring_algorithm` crate [#125], [#124]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curv-kzen"
-version = "0.8.0-rc2"
+version = "0.8.0-rc3"
 edition = "2018"
 authors = [
     "Omer Shlomovits",

--- a/src/elliptic/curves/wrappers/arithmetic.rs
+++ b/src/elliptic/curves/wrappers/arithmetic.rs
@@ -170,10 +170,10 @@ matrix! {
         (o_<> Point<E>, Point<E>), (o_<> Point<E>, &Point<E>),
         (o_<> Point<E>, Generator<E>),
 
-        (_o<> &Point<E>, Point<E>), (r_<> &Point<E>, &Point<E>),
+        (r_<> &Point<E>, Point<E>), (r_<> &Point<E>, &Point<E>),
         (r_<> &Point<E>, Generator<E>),
 
-        (_o<> Generator<E>, Point<E>), (r_<> Generator<E>, &Point<E>),
+        (r_<> Generator<E>, Point<E>), (r_<> Generator<E>, &Point<E>),
         (r_<> Generator<E>, Generator<E>),
     }
 }
@@ -222,7 +222,7 @@ matrix! {
     point_assign_fn = sub_assign,
     pairs = {
         (o_<> Scalar<E>, Scalar<E>), (o_<> Scalar<E>, &Scalar<E>),
-        (_o<> &Scalar<E>, Scalar<E>), (r_<> &Scalar<E>, &Scalar<E>),
+        (r_<> &Scalar<E>, Scalar<E>), (r_<> &Scalar<E>, &Scalar<E>),
     }
 }
 


### PR DESCRIPTION
I caught a bug — for two points `a: Point<E>` and `b: Point<E>`, expression `&a - b` produces wrong result (it actually returns `b - a`). PR fixes it.