### PR TITLE
Replace secp256k1 with libsecp256k1 pure rust implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,6 @@ num-bigint = { version = "0.4", features = ["serde"], optional = true }
 
 secp256k1 = { package = "libsecp256k1", git = "https://github.com/Gauthamastro/libsecp256k1.git" }
 
-#[dependencies.secp256k1]
-#version = "0.20"
-#features = ["serde", "rand-std", "global-context"]
-
 [dependencies.p256]
 version = "0.9"
 features = ["ecdsa", "ecdsa-core", "zeroize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,11 @@ zeroize = "1"
 rust-gmp-kzen = { version = "0.5", features = ["serde_support"], optional = true }
 num-bigint = { version = "0.4", features = ["serde"], optional = true }
 
-[dependencies.secp256k1]
-version = "0.20"
-features = ["serde", "rand-std", "global-context"]
+secp256k1 = { package = "libsecp256k1", git = "https://github.com/Gauthamastro/libsecp256k1.git" }
+
+#[dependencies.secp256k1]
+#version = "0.20"
+#features = ["serde", "rand-std", "global-context"]
 
 [dependencies.p256]
 version = "0.9"
@@ -62,4 +64,4 @@ proptest-derive = "0.2"
 default = ["rust-gmp-kzen"]
 
 [package.metadata.docs.rs]
-rustdoc-args = [ "--html-in-header", "katex-header.html" ]
+rustdoc-args = ["--html-in-header", "katex-header.html"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ The library has a built in support for some useful operations/primitives such as
 schemes, zero knowledge proofs, and simple two party protocols such as ECDH and coin flip. The library comes with 
 serialize/deserialize support to be used in higher level code to implement networking. 
 
+cryptographic_primitives::proofs::sigma_correct_homomorphic_elgamal_encryption_of_dlog::tests::test_correct_homo_elgamal_secp256k1
+elliptic::curves::test::point_negation_secp256k1
+elliptic::curves::test::test_point_subtraction_secp256k1
+elliptic::curves::test::zero_point_arithmetic_secp256k1
+
 ### Usage
 
 To use `curv` crate, add the following to your Cargo.toml:

--- a/README.md
+++ b/README.md
@@ -10,12 +10,7 @@ Use this library for general purpose elliptic curve cryptography.
 
 The library has a built in support for some useful operations/primitives such as verifiable secret sharing, commitment 
 schemes, zero knowledge proofs, and simple two party protocols such as ECDH and coin flip. The library comes with 
-serialize/deserialize support to be used in higher level code to implement networking. 
-
-cryptographic_primitives::proofs::sigma_correct_homomorphic_elgamal_encryption_of_dlog::tests::test_correct_homo_elgamal_secp256k1
-elliptic::curves::test::point_negation_secp256k1
-elliptic::curves::test::test_point_subtraction_secp256k1
-elliptic::curves::test::zero_point_arithmetic_secp256k1
+serialize/deserialize support to be used in higher level code to implement networking.
 
 ### Usage
 

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -434,27 +434,25 @@ impl ECPoint for Secp256k1Point {
                 purpose: "from_bytes",
                 ge: None,
             })
+        } else if bytes.len() == 33 {
+            let pk = PublicKey::parse_compressed(<&[u8; 33]>::try_from(bytes).unwrap())
+                .map_err(|_| DeserializationError)?;
+            Ok(Secp256k1Point {
+                purpose: "from_bytes",
+                ge: Some(PK(pk)),
+            })
+        } else if bytes.len() == 65 {
+            let pk = PublicKey::parse(<&[u8; 65]>::try_from(bytes).unwrap())
+                .map_err(|_| DeserializationError)?;
+            Ok(Secp256k1Point {
+                purpose: "from_bytes",
+                ge: Some(PK(pk)),
+            })
         } else {
-            if bytes.len() == 33 {
-                let pk = PublicKey::parse_compressed(<&[u8; 33]>::try_from(bytes).unwrap())
-                    .map_err(|_| DeserializationError)?;
-                Ok(Secp256k1Point {
-                    purpose: "from_bytes",
-                    ge: Some(PK(pk)),
-                })
-            } else if bytes.len() == 65 {
-                let pk = PublicKey::parse(<&[u8; 65]>::try_from(bytes).unwrap())
-                    .map_err(|_| DeserializationError)?;
-                Ok(Secp256k1Point {
-                    purpose: "from_bytes",
-                    ge: Some(PK(pk)),
-                })
-            } else {
-                Ok(Secp256k1Point {
-                    purpose: "from_bytes",
-                    ge: None,
-                })
-            }
+            Ok(Secp256k1Point {
+                purpose: "from_bytes",
+                ge: None,
+            })
         }
     }
 


### PR DESCRIPTION
PR replaces secp256k1 with libsecp256k1 pure implementation from paritytech.