### PR TITLE
Fix a bug in HmacExt::verify_bigint

### DIFF
--- a/src/cryptographic_primitives/hashing/ext.rs
+++ b/src/cryptographic_primitives/hashing/ext.rs
@@ -2,6 +2,7 @@ use digest::Digest;
 use hmac::crypto_mac::MacError;
 use hmac::{Hmac, Mac, NewMac};
 use typenum::Unsigned;
+use generic_array::GenericArray;
 
 use crate::arithmetic::*;
 use crate::elliptic::curves::{Curve, ECScalar, Point, Scalar};
@@ -162,7 +163,14 @@ where
     }
 
     fn verify_bigint(self, code: &BigInt) -> Result<(), MacError> {
-        self.verify(&code.to_bytes())
+        let mut code_array = GenericArray::<u8, <D as digest::FixedOutput>::OutputSize>::default();
+        let code_length = code_array.len();
+        let bytes = code.to_bytes();
+        if bytes.len() > code_length {
+            return Err(MacError);
+        }
+        code_array[code_length - bytes.len()..].copy_from_slice(&bytes);
+        self.verify(&code_array)
     }
 }
 


### PR DESCRIPTION
Every once in a while I get tests failing like this a few weeks ago:
```rust
---- cryptographic_primitives::hashing::ext::test::create_hmac_test_blake2b stdout ----
thread 'cryptographic_primitives::hashing::ext::test::create_hmac_test_blake2b' panicked at 'assertion failed: Hmac::<H>::new_bigint(&key).chain_bigint(&BigInt::from(10)).verify_bigint(&result1).is_ok()', src/cryptographic_primitives/hashing/ext.rs:306:9

---- cryptographic_primitives::hashing::ext::test::create_hmac_test_sha512 stdout ----
thread 'cryptographic_primitives::hashing::ext::test::create_hmac_test_sha512' panicked at 'assertion failed: Hmac::<H>::new_bigint(&key).chain_bigint(&BigInt::from(10)).verify_bigint(&result1).is_ok()', src/cryptographic_primitives/hashing/ext.rs:306:9


failures:
    cryptographic_primitives::hashing::ext::test::create_hmac_test_blake2b
    cryptographic_primitives::hashing::ext::test::create_hmac_test_sha512

test result: FAILED. 475 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.16s
```

and this today:
```rust
---- cryptographic_primitives::hashing::ext::test::create_hmac_test_sha3_512 stdout ----
thread 'cryptographic_primitives::hashing::ext::test::create_hmac_test_sha3_512' panicked at 'assertion failed: Hmac::<H>::new_bigint(&key).chain_bigint(&BigInt::from(10)).verify_bigint(&result1).is_ok()', src/cryptographic_primitives/hashing/ext.rs:306:9
```

The reason was that we converted BigInt to a vector and then compared that means that if the least significant byte was 0 it returned 32 bytes instead of 33 (or 63 bytes instead of 64).

We fix it by copying into an array of the right size.