### PR TITLE
Fix: zeroize Point and BigInt on drop, and other zeroize changes

### DIFF
--- a/src/arithmetic/big_gmp.rs
+++ b/src/arithmetic/big_gmp.rs
@@ -15,13 +15,11 @@
 */
 
 use std::convert::{TryFrom, TryInto};
-use std::sync::atomic;
-use std::{fmt, ops, ptr};
+use std::{fmt, ops};
 
 use gmp::mpz::Mpz;
 use gmp::sign::Sign;
 use num_traits::{One, Zero};
-use zeroize::Zeroize;
 
 use super::errors::*;
 use super::traits::*;
@@ -48,23 +46,6 @@ impl BigInt {
     }
     fn into_inner(self) -> Mpz {
         self.gmp
-    }
-}
-
-#[allow(deprecated)]
-impl ZeroizeBN for BigInt {
-    fn zeroize_bn(&mut self) {
-        unsafe { ptr::write_volatile(&mut self.gmp, Mpz::zero()) };
-        atomic::fence(atomic::Ordering::SeqCst);
-        atomic::compiler_fence(atomic::Ordering::SeqCst);
-    }
-}
-
-impl Zeroize for BigInt {
-    fn zeroize(&mut self) {
-        unsafe { ptr::write_volatile(&mut self.gmp, Mpz::zero()) };
-        atomic::fence(atomic::Ordering::SeqCst);
-        atomic::compiler_fence(atomic::Ordering::SeqCst);
     }
 }
 

--- a/src/arithmetic/big_native.rs
+++ b/src/arithmetic/big_native.rs
@@ -1,5 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 use std::{fmt, ops};
+use core::{ptr, sync::atomic};
 
 use num_traits::Signed;
 
@@ -36,16 +37,8 @@ impl BigInt {
     }
 }
 
-#[allow(deprecated)]
-impl ZeroizeBN for BigInt {
-    fn zeroize_bn(&mut self) {
-        zeroize::Zeroize::zeroize(self)
-    }
-}
-
-impl Zeroize for BigInt {
-    fn zeroize(&mut self) {
-        use core::{ptr, sync::atomic};
+impl Drop for BigInt {
+    fn drop(&mut self) {
         // Copy the inner so we can read the data inside
         let original = unsafe { ptr::read(&mut self.num) };
         // Replace self with a zeroed integer.
@@ -58,12 +51,6 @@ impl Zeroize for BigInt {
         let mut data: Vec<usize> = unsafe { core::mem::transmute(uint) };
         atomic::compiler_fence(atomic::Ordering::SeqCst);
         data.zeroize();
-    }
-}
-
-impl Drop for BigInt {
-    fn drop(&mut self) {
-        self.zeroize();
     }
 }
 

--- a/src/arithmetic/big_native.rs
+++ b/src/arithmetic/big_native.rs
@@ -44,8 +44,8 @@ impl ZeroizeBN for BigInt {
 
 impl zeroize::Zeroize for BigInt {
     fn zeroize(&mut self) {
-        use std::{ptr, sync::atomic};
-        unsafe { ptr::write_volatile(&mut self.num, Zero::zero()) };
+        use std::sync::atomic;
+        self.num *= 0;
         atomic::fence(atomic::Ordering::SeqCst);
         atomic::compiler_fence(atomic::Ordering::SeqCst);
     }

--- a/src/arithmetic/mod.rs
+++ b/src/arithmetic/mod.rs
@@ -377,10 +377,9 @@ mod test {
         T: Converter + BasicOps + Modulo + Samplable + NumberTests + EGCD + BitManipulation,
         T: Primes,
         // Deprecated but not deleted yet traits from self::traits module
-        T: ZeroizeBN,
         u64: ConvertFrom<BigInt>,
         // Foreign traits implementations
-        T: zeroize::Zeroize + num_traits::One + num_traits::Zero,
+        T: num_traits::One + num_traits::Zero,
         T: num_traits::Num + num_integer::Integer + num_integer::Roots,
         // Conversion traits
         for<'a> u64: std::convert::TryFrom<&'a BigInt>,
@@ -456,5 +455,14 @@ mod test {
             + SubAssign<&'a BigInt>
             + SubAssign<u64>,
     {
+    }
+
+    #[test]
+    fn test_bigint_zeroize() {
+        let n = BigInt::from(42);
+        println!("n = {:?}, &n = {:p}", n, &n);
+        let n_ptr = &n as *const BigInt;
+        drop(n);
+        println!("*n_ptr = {:?}", unsafe { (*n_ptr).clone() });
     }
 }

--- a/src/arithmetic/mod.rs
+++ b/src/arithmetic/mod.rs
@@ -456,13 +456,4 @@ mod test {
             + SubAssign<u64>,
     {
     }
-
-    #[test]
-    fn test_bigint_zeroize() {
-        let n = BigInt::from(42);
-        println!("n = {:?}, &n = {:p}", n, &n);
-        let n_ptr = &n as *const BigInt;
-        drop(n);
-        println!("*n_ptr = {:?}", unsafe { (*n_ptr).clone() });
-    }
 }

--- a/src/cryptographic_primitives/commitments/pedersen_commitment.rs
+++ b/src/cryptographic_primitives/commitments/pedersen_commitment.rs
@@ -6,6 +6,7 @@
 */
 
 use std::marker::PhantomData;
+use zeroize::Zeroizing;
 
 use super::traits::Commitment;
 use super::SECURITY_BITS;
@@ -29,9 +30,9 @@ impl<E: Curve> Commitment<Point<E>> for PedersenCommitment<E> {
         let h = Point::base_point2();
         let message_scalar: Scalar<E> = Scalar::from(message);
         let blinding_scalar: Scalar<E> = Scalar::from(blinding_factor);
-        let mg = g * message_scalar;
-        let rh = h * blinding_scalar;
-        mg + rh
+        let mg = Zeroizing::new(g * message_scalar);
+        let rh = Zeroizing::new(h * blinding_scalar);
+        &*mg + &*rh
     }
 
     fn create_commitment(message: &BigInt) -> (Point<E>, BigInt) {

--- a/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_enc.rs
+++ b/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_enc.rs
@@ -9,6 +9,8 @@
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 
+use zeroize::Zeroizing;
+
 use crate::cryptographic_primitives::hashing::DigestExt;
 use crate::elliptic::curves::{Curve, Point, Scalar};
 use crate::marker::HashChoice;
@@ -56,10 +58,10 @@ impl<E: Curve, H: Digest + Clone> HomoELGamalProof<E, H> {
     ) -> HomoELGamalProof<E, H> {
         let s1: Scalar<E> = Scalar::random();
         let s2: Scalar<E> = Scalar::random();
-        let A1 = &delta.H * &s1;
-        let A2 = &delta.Y * &s2;
+        let A1 = Zeroizing::new(&delta.H * &s1);
+        let A2 = Zeroizing::new(&delta.Y * &s2);
         let A3 = &delta.G * &s2;
-        let T = A1 + A2;
+        let T = &*A1 + &*A2;
         let e = H::new()
             .chain_point(&T)
             .chain_point(&A3)

--- a/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_enc.rs
+++ b/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_enc.rs
@@ -71,14 +71,12 @@ impl<E: Curve, H: Digest + Clone> HomoELGamalProof<E, H> {
             .chain_point(&delta.D)
             .chain_point(&delta.E)
             .result_scalar();
-        // dealing with zero field element
-        let z1 = &s1 + &w.x * &e;
-        let z2 = s2 + &w.r * e;
         HomoELGamalProof {
             T,
             A3,
-            z1,
-            z2,
+            // dealing with zero field element
+            z1: &s1 + &w.x * &e,
+            z2: s2 + &w.r * e,
             hash_choice: HashChoice::new(),
         }
     }

--- a/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_encryption_of_dlog.rs
+++ b/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_encryption_of_dlog.rs
@@ -62,14 +62,12 @@ impl<E: Curve, H: Digest + Clone> HomoELGamalDlogProof<E, H> {
         let e = H::new()
             .chain_points([&A1, &A2, &A3, &delta.G, &delta.Y, &delta.D, &delta.E])
             .result_scalar();
-        let z1 = &s1 + &e * &w.x;
-        let z2 = &s2 + e * &w.r;
         HomoELGamalDlogProof {
             A1,
             A2,
             A3,
-            z1,
-            z2,
+            z1: &s1 + &e * &w.x,
+            z2: &s2 + e * &w.r,
             hash_choice: HashChoice::new(),
         }
     }

--- a/src/cryptographic_primitives/proofs/sigma_dlog.rs
+++ b/src/cryptographic_primitives/proofs/sigma_dlog.rs
@@ -49,11 +49,10 @@ impl<E: Curve, H: Digest + Clone> DLogProof<E, H> {
             .result_scalar();
 
         let challenge_mul_sk = challenge * sk;
-        let challenge_response = &sk_t_rand_commitment - &challenge_mul_sk;
         DLogProof {
             pk,
             pk_t_rand_commitment,
-            challenge_response,
+            challenge_response: &sk_t_rand_commitment - &challenge_mul_sk,
             hash_choice: HashChoice::new(),
         }
     }

--- a/src/cryptographic_primitives/proofs/sigma_ec_ddh.rs
+++ b/src/cryptographic_primitives/proofs/sigma_ec_ddh.rs
@@ -61,11 +61,10 @@ impl<E: Curve, H: Digest + Clone> ECDDHProof<E, H> {
             .chain_point(&a1)
             .chain_point(&a2)
             .result_scalar();
-        let z = &s + e * &w.x;
         ECDDHProof {
             a1,
             a2,
-            z,
+            z: &s + e * &w.x,
             hash_choice: HashChoice::new(),
         }
     }

--- a/src/cryptographic_primitives/proofs/sigma_valid_pedersen.rs
+++ b/src/cryptographic_primitives/proofs/sigma_valid_pedersen.rs
@@ -56,17 +56,15 @@ impl<E: Curve, H: Digest + Clone> PedersenProof<E, H> {
             .result_scalar();
 
         let em = &e * m;
-        let z1 = &s1 + em;
         let er = &e * r;
-        let z2 = &s2 + er;
 
         PedersenProof {
-            e,
+            e: e.clone(),
             a1,
             a2,
             com,
-            z1,
-            z2,
+            z1: &s1 + em,
+            z2: &s2 + er,
             hash_choice: HashChoice::new(),
         }
     }

--- a/src/cryptographic_primitives/proofs/sigma_valid_pedersen_blind.rs
+++ b/src/cryptographic_primitives/proofs/sigma_valid_pedersen_blind.rs
@@ -53,13 +53,12 @@ impl<E: Curve, H: Digest + Clone> PedersenBlindingProof<E, H> {
             .result_scalar();
 
         let er = &e * r;
-        let z = &s + &er;
         PedersenBlindingProof {
-            e,
+            e: e.clone(),
             m: m.clone(),
             a,
             com,
-            z,
+            z: &s + &er,
             hash_choice: HashChoice::new(),
         }
     }

--- a/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
+++ b/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
@@ -24,8 +24,8 @@ pub struct ShamirSecretSharing {
 /// Feldman VSS, based on  Paul Feldman. 1987. A practical scheme for non-interactive verifiable secret sharing.
 /// In Foundations of Computer Science, 1987., 28th Annual Symposium on.IEEE, 427–43
 ///
-/// implementation details: The code is using FE and GE. Each party is given an index from 1,..,n and a secret share of type FE.
-/// The index of the party is also the point on the polynomial where we treat this number as u32 but converting it to FE internally.
+/// Implementation details: The code is generic over the curve. Each party is given an index from `1,..,n` and a secret share of type `Scalar<E>`.
+/// The index of the party is also the point on the polynomial where we treat this number as `u32` but converting it to `Scalar<E>` internally.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct VerifiableSS<E: Curve> {

--- a/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
+++ b/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
@@ -56,7 +56,7 @@ impl<E: Curve> VerifiableSS<E> {
     // generate VerifiableSS from a secret
     pub fn share(t: u16, n: u16, secret: &Scalar<E>) -> (VerifiableSS<E>, SecretShares<E>) {
         assert!(t < n);
-        let polynomial = Polynomial::<E>::sample_exact_with_fixed_const_term(t, secret.clone());
+        let polynomial = Polynomial::<E>::sample_exact_with_fixed_const_term(t, &secret);
         let shares = polynomial.evaluate_many_bigint(1..=n).collect();
 
         let g = Point::<E>::generator();
@@ -83,7 +83,7 @@ impl<E: Curve> VerifiableSS<E> {
         let n = self.parameters.share_count;
 
         let one = Scalar::<E>::from(1);
-        let poly = Polynomial::<E>::sample_exact_with_fixed_const_term(t, one.clone());
+        let poly = Polynomial::<E>::sample_exact_with_fixed_const_term(t, &one);
         let secret_shares_biased: Vec<_> = poly.evaluate_many_bigint(1..=n).collect();
         let secret_shares: Vec<_> = (0..secret_shares_biased.len())
             .map(|i| &secret_shares_biased[i] - &one)
@@ -111,7 +111,7 @@ impl<E: Curve> VerifiableSS<E> {
     ) -> (VerifiableSS<E>, SecretShares<E>) {
         assert_eq!(usize::from(n), index_vec.len());
 
-        let polynomial = Polynomial::<E>::sample_exact_with_fixed_const_term(t, secret.clone());
+        let polynomial = Polynomial::<E>::sample_exact_with_fixed_const_term(t, &secret);
         let shares = polynomial
             .evaluate_many_bigint(index_vec.iter().cloned())
             .collect();
@@ -137,7 +137,7 @@ impl<E: Curve> VerifiableSS<E> {
     // returns vector of coefficients
     #[deprecated(since = "0.8.0", note = "please use Polynomial::sample instead")]
     pub fn sample_polynomial(t: usize, coef0: &Scalar<E>) -> Vec<Scalar<E>> {
-        Polynomial::<E>::sample_exact_with_fixed_const_term(t.try_into().unwrap(), coef0.clone())
+        Polynomial::<E>::sample_exact_with_fixed_const_term(t.try_into().unwrap(), &coef0)
             .coefficients()
             .to_vec()
     }
@@ -153,8 +153,8 @@ impl<E: Curve> VerifiableSS<E> {
     }
 
     #[deprecated(since = "0.8.0", note = "please use Polynomial::evaluate instead")]
-    pub fn mod_evaluate_polynomial(coefficients: &[Scalar<E>], point: Scalar<E>) -> Scalar<E> {
-        Polynomial::<E>::from_coefficients(coefficients.to_vec()).evaluate(&point)
+    pub fn mod_evaluate_polynomial(coefficients: &[Scalar<E>], point: &Scalar<E>) -> Scalar<E> {
+        Polynomial::<E>::from_coefficients(coefficients.to_vec()).evaluate(point)
     }
 
     pub fn reconstruct(&self, indices: &[u16], shares: &[Scalar<E>]) -> Scalar<E> {

--- a/src/cryptographic_primitives/secret_sharing/polynomial.rs
+++ b/src/cryptographic_primitives/secret_sharing/polynomial.rs
@@ -113,16 +113,16 @@ impl<E: Curve> Polynomial<E> {
     /// use curv::elliptic::curves::{Secp256k1, Scalar};
     ///
     /// let const_term = Scalar::<Secp256k1>::random();
-    /// let polynomial = Polynomial::<Secp256k1>::sample_exact_with_fixed_const_term(3, const_term.clone());
+    /// let polynomial = Polynomial::<Secp256k1>::sample_exact_with_fixed_const_term(3, &const_term);
     /// assert_eq!(polynomial.degree(), 3.into());
     /// assert_eq!(polynomial.evaluate(&Scalar::zero()), const_term);
     /// ```
-    pub fn sample_exact_with_fixed_const_term(n: u16, const_term: Scalar<E>) -> Self {
+    pub fn sample_exact_with_fixed_const_term(n: u16, const_term: &Scalar<E>) -> Self {
         if n == 0 {
-            Self::from_coefficients(vec![const_term])
+            Self::from_coefficients(vec![const_term.clone()])
         } else {
             let random_coefficients = iter::repeat_with(Scalar::random).take(usize::from(n));
-            Self::from_coefficients(iter::once(const_term).chain(random_coefficients).collect())
+            Self::from_coefficients(iter::once(const_term.clone()).chain(random_coefficients).collect())
         }
     }
 

--- a/src/cryptographic_primitives/twoparty/coin_flip_optimal_rounds.rs
+++ b/src/cryptographic_primitives/twoparty/coin_flip_optimal_rounds.rs
@@ -15,7 +15,7 @@ use crate::cryptographic_primitives::proofs::sigma_valid_pedersen_blind::Pederse
 use crate::elliptic::curves::{Curve, Point, Scalar};
 
 /// based on How To Simulate It – A Tutorial on the Simulation
-/// Proof Technique. protocol 7.3: Multiple coin tossing. which provide simulatble constant round
+/// Proof Technique. protocol 7.3: Multiple coin tossing. which provide simulatable constant round
 /// coin toss
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(bound = "")]

--- a/src/cryptographic_primitives/twoparty/coin_flip_optimal_rounds.rs
+++ b/src/cryptographic_primitives/twoparty/coin_flip_optimal_rounds.rs
@@ -45,8 +45,7 @@ impl<E: Curve, H: Digest + Clone> Party1FirstMessage<E, H> {
 impl<E: Curve> Party2FirstMessage<E> {
     pub fn share<H: Digest + Clone>(proof: &PedersenProof<E, H>) -> Party2FirstMessage<E> {
         PedersenProof::verify(proof).expect("{(m,r),c} proof failed");
-        let seed = Scalar::random();
-        Party2FirstMessage { seed }
+        Party2FirstMessage { seed: Scalar::random() }
     }
 }
 impl<E: Curve, H: Digest + Clone> Party1SecondMessage<E, H> {

--- a/src/cryptographic_primitives/twoparty/dh_key_exchange.rs
+++ b/src/cryptographic_primitives/twoparty/dh_key_exchange.rs
@@ -51,13 +51,13 @@ impl<E: Curve> Party1FirstMessage<E> {
     }
 
     pub fn first_with_fixed_secret_share(
-        secret_share: Scalar<E>,
+        secret_share: &Scalar<E>,
     ) -> (Party1FirstMessage<E>, EcKeyPair<E>) {
-        let public_share = Point::generator() * secret_share.clone();
+        let public_share = Point::generator() * secret_share;
 
         let ec_key_pair = EcKeyPair {
             public_share: public_share.clone(),
-            secret_share,
+            secret_share: secret_share.clone(),
         };
         (Party1FirstMessage { public_share }, ec_key_pair)
     }
@@ -76,12 +76,12 @@ impl<E: Curve> Party2FirstMessage<E> {
     }
 
     pub fn first_with_fixed_secret_share(
-        secret_share: Scalar<E>,
+        secret_share: &Scalar<E>,
     ) -> (Party2FirstMessage<E>, EcKeyPair<E>) {
-        let public_share = Point::generator() * &secret_share;
+        let public_share = Point::generator() * secret_share;
         let ec_key_pair = EcKeyPair {
             public_share: public_share.clone(),
-            secret_share,
+            secret_share: secret_share.clone(),
         };
         (Party2FirstMessage { public_share }, ec_key_pair)
     }
@@ -123,11 +123,11 @@ mod tests {
     fn test_dh_key_exchange_fixed_shares<E: Curve>() {
         let secret_party_1 = Scalar::try_from(&BigInt::from(1)).unwrap();
         let (kg_party_one_first_message, kg_ec_key_pair_party1) =
-            Party1FirstMessage::<E>::first_with_fixed_secret_share(secret_party_1);
+            Party1FirstMessage::<E>::first_with_fixed_secret_share(&secret_party_1);
         let secret_party_2 = Scalar::try_from(&BigInt::from(2)).unwrap();
 
         let (kg_party_two_first_message, kg_ec_key_pair_party2) =
-            Party2FirstMessage::first_with_fixed_secret_share(secret_party_2.clone());
+            Party2FirstMessage::first_with_fixed_secret_share(&secret_party_2);
 
         assert_eq!(
             compute_pubkey(

--- a/src/cryptographic_primitives/twoparty/dh_key_exchange.rs
+++ b/src/cryptographic_primitives/twoparty/dh_key_exchange.rs
@@ -45,7 +45,7 @@ impl<E: Curve> Party1FirstMessage<E> {
 
         let ec_key_pair = EcKeyPair {
             public_share: public_share.clone(),
-            secret_share,
+            secret_share: secret_share.clone(),
         };
         (Party1FirstMessage { public_share }, ec_key_pair)
     }
@@ -70,7 +70,7 @@ impl<E: Curve> Party2FirstMessage<E> {
         let public_share = base * &secret_share;
         let ec_key_pair = EcKeyPair {
             public_share: public_share.clone(),
-            secret_share,
+            secret_share: secret_share.clone(),
         };
         (Party2FirstMessage { public_share }, ec_key_pair)
     }

--- a/src/cryptographic_primitives/twoparty/dh_key_exchange_variant_with_pok_comm.rs
+++ b/src/cryptographic_primitives/twoparty/dh_key_exchange_variant_with_pok_comm.rs
@@ -90,7 +90,7 @@ impl Party1FirstMessage {
         );
         let ec_key_pair = EcKeyPair {
             public_share,
-            secret_share,
+            secret_share: secret_share.clone(),
         };
         (
             Party1FirstMessage {
@@ -164,7 +164,7 @@ impl<E: Curve, H: Digest + Clone> Party2FirstMessage<E, H> {
         let d_log_proof = DLogProof::prove(&secret_share);
         let ec_key_pair = EcKeyPair {
             public_share: public_share.clone(),
-            secret_share,
+            secret_share: secret_share.clone(),
         };
         (
             Party2FirstMessage {

--- a/src/cryptographic_primitives/twoparty/dh_key_exchange_variant_with_pok_comm.rs
+++ b/src/cryptographic_primitives/twoparty/dh_key_exchange_variant_with_pok_comm.rs
@@ -108,10 +108,10 @@ impl Party1FirstMessage {
     }
 
     pub fn create_commitments_with_fixed_secret_share<E: Curve, H: Digest + Clone>(
-        secret_share: Scalar<E>,
+        secret_share: &Scalar<E>,
     ) -> (Party1FirstMessage, CommWitness<E, H>, EcKeyPair<E>) {
         let base = Point::<E>::generator();
-        let public_share = base * &secret_share;
+        let public_share = base * secret_share;
 
         let d_log_proof = DLogProof::prove(&secret_share);
 
@@ -129,7 +129,7 @@ impl Party1FirstMessage {
 
         let ec_key_pair = EcKeyPair {
             public_share,
-            secret_share,
+            secret_share: secret_share.clone(),
         };
         (
             Party1FirstMessage {
@@ -176,14 +176,14 @@ impl<E: Curve, H: Digest + Clone> Party2FirstMessage<E, H> {
     }
 
     pub fn create_with_fixed_secret_share(
-        secret_share: Scalar<E>,
+        secret_share: &Scalar<E>,
     ) -> (Party2FirstMessage<E, H>, EcKeyPair<E>) {
         let base = Point::generator();
-        let public_share = base * &secret_share;
+        let public_share = base * secret_share;
         let d_log_proof = DLogProof::prove(&secret_share);
         let ec_key_pair = EcKeyPair {
             public_share: public_share.clone(),
-            secret_share,
+            secret_share: secret_share.clone(),
         };
         (
             Party2FirstMessage {

--- a/src/elliptic/curves/test.rs
+++ b/src/elliptic/curves/test.rs
@@ -4,6 +4,8 @@ use std::iter;
 
 use rand::{rngs::OsRng, Rng};
 
+use zeroize::Zeroize;
+
 use crate::arithmetic::*;
 use crate::test_for_all_curves;
 
@@ -357,4 +359,15 @@ fn scalar_assign_negation<E: Curve>() {
         s
     };
     assert_eq!(s_neg_1, s_neg_2);
+}
+
+test_for_all_curves!(point_zeroize);
+fn point_zeroize<E: Curve>() {
+    let mut first_point = E::Point::generator().scalar_mul(&random_nonzero_scalar());
+    let first_copy = first_point.clone();
+    first_point.zeroize();
+    assert_ne!(first_point, first_copy);
+    let mut second_point = E::Point::generator().scalar_mul(&random_nonzero_scalar());
+    second_point.zeroize();
+    assert_eq!(first_point, second_point);
 }

--- a/src/elliptic/curves/wrappers/point.rs
+++ b/src/elliptic/curves/wrappers/point.rs
@@ -1,5 +1,7 @@
 use std::{fmt, iter};
 
+use zeroize::Zeroize;
+
 use crate::elliptic::curves::traits::*;
 use crate::BigInt;
 
@@ -305,5 +307,11 @@ impl<E: Curve> iter::Sum for Point<E> {
 impl<'p, E: Curve> iter::Sum<&'p Point<E>> for Point<E> {
     fn sum<I: Iterator<Item = &'p Point<E>>>(iter: I) -> Self {
         iter.fold(Point::zero(), |acc, p| acc + p)
+    }
+}
+
+impl<E: Curve> Zeroize for Point<E> {
+    fn zeroize(&mut self) {
+        self.raw_point.zeroize();
     }
 }


### PR DESCRIPTION
- `Impl Zeroize for Point<E>`;
- `Zeroizing<Point<E>>` for points that need to be zeroized;
- zeroize num-bigint properly and on drop;
- delete implementation of `Zeroize` for BigInts.