### PR TITLE
Add a cautionary assert to `share_at_indices` to prevent user from misusing the api and passing 0 as index

### DIFF
--- a/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
+++ b/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
@@ -110,6 +110,10 @@ impl<E: Curve> VerifiableSS<E> {
         index_vec: &[u16],
     ) -> (VerifiableSS<E>, SecretShares<E>) {
         assert_eq!(usize::from(n), index_vec.len());
+        assert!(
+            !index_vec.iter().any(|&i| i == 0),
+            "Sharing to index 0 will reveal the secret"
+        );
 
         let polynomial = Polynomial::<E>::sample_exact_with_fixed_const_term(t, secret.clone());
         let shares = polynomial

--- a/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
+++ b/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
@@ -7,6 +7,7 @@
 */
 
 use std::convert::{TryFrom, TryInto};
+use std::num::NonZeroU16;
 use std::{fmt, ops};
 
 use serde::{Deserialize, Serialize};
@@ -103,22 +104,23 @@ impl<E: Curve> VerifiableSS<E> {
     }
 
     /// generate VerifiableSS from a secret and user defined x values (in case user wants to distribute point f(1), f(4), f(6) and not f(1),f(2),f(3))
-    /// NOTE: The caller should make sure that `t`, `n` and the contents of `index_vec` can't be controlled by a malicious party..
-    pub fn share_at_indices(
+    /// NOTE: The caller should make sure that `t`, `n` and the contents of `index_vec` can't be controlled by a malicious party.
+    pub fn share_at_indices<I>(
         t: u16,
         n: u16,
         secret: &Scalar<E>,
-        index_vec: &[u16],
-    ) -> (VerifiableSS<E>, SecretShares<E>) {
-        assert_eq!(usize::from(n), index_vec.len());
-        assert!(
-            !index_vec.iter().any(|&i| i == 0),
-            "Sharing to index 0 will reveal the secret"
-        );
+        indicies: I,
+    ) -> (VerifiableSS<E>, SecretShares<E>)
+    where
+        I: IntoIterator<Item = NonZeroU16>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let indicies = indicies.into_iter();
+        assert_eq!(usize::from(n), indicies.len());
 
         let polynomial = Polynomial::<E>::sample_exact_with_fixed_const_term(t, secret.clone());
         let shares = polynomial
-            .evaluate_many_bigint(index_vec.iter().cloned())
+            .evaluate_many_bigint(indicies.map(NonZeroU16::get))
             .collect();
 
         let g = Point::<E>::generator();
@@ -291,8 +293,12 @@ mod tests {
     fn test_secret_sharing_3_out_of_5_at_indices<E: Curve>() {
         let secret = Scalar::random();
         let parties = [1, 2, 4, 5, 6];
-        let (vss_scheme, secret_shares) =
-            VerifiableSS::<E>::share_at_indices(3, 5, &secret, &parties);
+        let (vss_scheme, secret_shares) = VerifiableSS::<E>::share_at_indices(
+            3,
+            5,
+            &secret,
+            parties.iter().map(|&v| NonZeroU16::new(v).unwrap()),
+        );
 
         let shares_vec = vec![
             secret_shares[0].clone(),

--- a/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
+++ b/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
@@ -102,7 +102,8 @@ impl<E: Curve> VerifiableSS<E> {
         )
     }
 
-    // generate VerifiableSS from a secret and user defined x values (in case user wants to distribute point f(1), f(4), f(6) and not f(1),f(2),f(3))
+    /// generate VerifiableSS from a secret and user defined x values (in case user wants to distribute point f(1), f(4), f(6) and not f(1),f(2),f(3))
+    /// NOTE: The caller should make sure that `t`, `n` and the contents of `index_vec` can't be controlled by a malicious party..
     pub fn share_at_indices(
         t: u16,
         n: u16,


### PR DESCRIPTION
`VerifiableSS::share_at_indices` is meant for users to share a secret at `f(0)`, the caller of this API is required to check that the indexes aren't controlled by an attacker, as an attacker could say that their index is the same as some other party's index, or that it is zero, or even claim that it has multiple indices allowing it to have `t` points by its self.

Nonetheless after a report from Trail-Of-Bits we add a cautionary assert to make sure the indices don't contain any zeros, because this is the worst kind of API mistake the user can make (as it tells them the secret)