### PR TITLE
Improve (de)serialization

### DIFF
--- a/src/arithmetic/serde_support.rs
+++ b/src/arithmetic/serde_support.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use serde::de::{SeqAccess, Visitor};
+use serde::de::{Error, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::traits::Converter;
@@ -12,7 +12,11 @@ impl Serialize for BigInt {
         S: Serializer,
     {
         let bytes = self.to_bytes();
-        serializer.serialize_bytes(&bytes)
+        if !serializer.is_human_readable() {
+            serializer.serialize_bytes(&bytes)
+        } else {
+            serializer.serialize_str(&hex::encode(bytes))
+        }
     }
 }
 
@@ -47,8 +51,20 @@ impl<'de> Deserialize<'de> for BigInt {
                 }
                 Ok(BigInt::from_bytes(&bytes))
             }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let bytes = hex::decode(v).map_err(|_| E::custom("malformed hex encoding"))?;
+                Ok(BigInt::from_bytes(&bytes))
+            }
         }
 
-        deserializer.deserialize_bytes(BigintVisitor)
+        if !deserializer.is_human_readable() {
+            deserializer.deserialize_bytes(BigintVisitor)
+        } else {
+            deserializer.deserialize_str(BigintVisitor)
+        }
     }
 }


### PR DESCRIPTION
* Fixes point/scalar deserialization with bincode 
* Serializes points/scalars/bigints in hex format if serialization format is [human readable](https://docs.rs/serde/latest/serde/trait.Serializer.html#method.is_human_readable)

Closes #158 