### PR TITLE
Added a dlog proof to vss feldman to defend against the n-t+1 attack

### DIFF
--- a/examples/verifiable_secret_sharing.rs
+++ b/examples/verifiable_secret_sharing.rs
@@ -1,4 +1,5 @@
 use curv::elliptic::curves::*;
+use sha2::Sha256;
 
 /// secret_sharing_3_out_of_5
 /// Feldman VSS, based on  Paul Feldman. 1987. A practical scheme for non-interactive verifiable secret sharing.
@@ -16,7 +17,7 @@ pub fn secret_sharing_3_out_of_5<E: Curve>() {
 
     let secret = Scalar::random();
 
-    let (vss_scheme, secret_shares) = VerifiableSS::<E>::share(3, 5, &secret);
+    let (vss_scheme, secret_shares) = VerifiableSS::<E, Sha256>::share(3, 5, &secret);
 
     let shares_vec = vec![
         secret_shares[0].clone(),
@@ -42,11 +43,11 @@ pub fn secret_sharing_3_out_of_5<E: Curve>() {
 
     // test map (t,n) - (t',t')
     let s = &vec![0, 1, 2, 3, 4];
-    let l0 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
-    let l1 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 1, s);
-    let l2 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 2, s);
-    let l3 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 3, s);
-    let l4 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 4, s);
+    let l0 = VerifiableSS::<E, Sha256>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
+    let l1 = VerifiableSS::<E, Sha256>::map_share_to_new_params(&vss_scheme.parameters, 1, s);
+    let l2 = VerifiableSS::<E, Sha256>::map_share_to_new_params(&vss_scheme.parameters, 2, s);
+    let l3 = VerifiableSS::<E, Sha256>::map_share_to_new_params(&vss_scheme.parameters, 3, s);
+    let l4 = VerifiableSS::<E, Sha256>::map_share_to_new_params(&vss_scheme.parameters, 4, s);
 
     let w = l0 * secret_shares[0].clone()
         + l1 * secret_shares[1].clone()

--- a/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
+++ b/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
@@ -12,6 +12,8 @@ use std::{fmt, ops};
 
 use serde::{Deserialize, Serialize};
 
+use crate::cryptographic_primitives::hashing::Digest;
+use crate::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use crate::cryptographic_primitives::secret_sharing::Polynomial;
 use crate::elliptic::curves::{Curve, Point, Scalar};
 use crate::ErrorSS::{self, VerifyShareError};
@@ -27,11 +29,14 @@ pub struct ShamirSecretSharing {
 ///
 /// implementation details: The code is using FE and GE. Each party is given an index from 1,..,n and a secret share of type FE.
 /// The index of the party is also the point on the polynomial where we treat this number as u32 but converting it to FE internally.
+///
+/// The scheme is augmented with a dlog proof for the constant commitment to protect against n-t+1 attack
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct VerifiableSS<E: Curve> {
+pub struct VerifiableSS<E: Curve, H: Digest + Clone> {
     pub parameters: ShamirSecretSharing,
     pub commitments: Vec<Point<E>>,
+    pub proof: DLogProof<E, H>,
 }
 
 /// Shared secret produced by [VerifiableSS::share]
@@ -49,13 +54,13 @@ pub struct SecretShares<E: Curve> {
     polynomial: Polynomial<E>,
 }
 
-impl<E: Curve> VerifiableSS<E> {
+impl<E: Curve, H: Digest + Clone> VerifiableSS<E, H> {
     pub fn reconstruct_limit(&self) -> u16 {
         self.parameters.threshold + 1
     }
 
     // generate VerifiableSS from a secret
-    pub fn share(t: u16, n: u16, secret: &Scalar<E>) -> (VerifiableSS<E>, SecretShares<E>) {
+    pub fn share(t: u16, n: u16, secret: &Scalar<E>) -> (VerifiableSS<E, H>, SecretShares<E>) {
         assert!(t < n);
         let polynomial = Polynomial::<E>::sample_exact_with_fixed_const_term(t, secret.clone());
         let shares = polynomial.evaluate_many_bigint(1..=n).collect();
@@ -66,6 +71,8 @@ impl<E: Curve> VerifiableSS<E> {
             .iter()
             .map(|coef| g * coef)
             .collect::<Vec<_>>();
+
+        let proof = DLogProof::<E, H>::prove(&secret);
         (
             VerifiableSS {
                 parameters: ShamirSecretSharing {
@@ -73,13 +80,14 @@ impl<E: Curve> VerifiableSS<E> {
                     share_count: n,
                 },
                 commitments,
+                proof,
             },
             SecretShares { shares, polynomial },
         )
     }
 
     // takes given VSS and generates a new VSS for the same secret and a secret shares vector to match the new commitments
-    pub fn reshare(&self) -> (VerifiableSS<E>, Vec<Scalar<E>>) {
+    pub fn reshare(&self) -> (VerifiableSS<E, H>, Vec<Scalar<E>>) {
         let t = self.parameters.threshold;
         let n = self.parameters.share_count;
 
@@ -98,6 +106,7 @@ impl<E: Curve> VerifiableSS<E> {
             VerifiableSS {
                 parameters: self.parameters.clone(),
                 commitments: new_commitments,
+                proof: self.proof.clone(),
             },
             secret_shares,
         )
@@ -110,7 +119,7 @@ impl<E: Curve> VerifiableSS<E> {
         n: u16,
         secret: &Scalar<E>,
         indicies: I,
-    ) -> (VerifiableSS<E>, SecretShares<E>)
+    ) -> (VerifiableSS<E, H>, SecretShares<E>)
     where
         I: IntoIterator<Item = NonZeroU16>,
         I::IntoIter: ExactSizeIterator,
@@ -129,6 +138,8 @@ impl<E: Curve> VerifiableSS<E> {
             .iter()
             .map(|coef| g * coef)
             .collect::<Vec<Point<E>>>();
+
+        let proof = DLogProof::<E, H>::prove(&secret);
         (
             VerifiableSS {
                 parameters: ShamirSecretSharing {
@@ -136,6 +147,7 @@ impl<E: Curve> VerifiableSS<E> {
                     share_count: n,
                 },
                 commitments,
+                proof,
             },
             SecretShares { shares, polynomial },
         )
@@ -172,7 +184,7 @@ impl<E: Curve> VerifiableSS<E> {
             .iter()
             .map(|i| Scalar::from(*i + 1))
             .collect::<Vec<_>>();
-        VerifiableSS::<E>::lagrange_interpolation_at_zero(&points, shares)
+        VerifiableSS::<E, H>::lagrange_interpolation_at_zero(&points, shares)
     }
 
     // Performs a Lagrange interpolation in field Zp at the origin
@@ -224,6 +236,9 @@ impl<E: Curve> VerifiableSS<E> {
     }
 
     pub fn validate_share(&self, secret_share: &Scalar<E>, index: u16) -> Result<(), ErrorSS> {
+        if self.commitments[0] != self.proof.pk || !DLogProof::verify(&self.proof).is_ok() {
+            return Err(VerifyShareError);
+        }
         let g = Point::generator();
         let ss_point = g * secret_share;
         self.validate_share_public(&ss_point, index)
@@ -286,14 +301,14 @@ impl<E: Curve> ops::Deref for SecretShares<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_for_all_curves;
+    use crate::test_for_all_curves_and_hashes;
 
-    test_for_all_curves!(test_secret_sharing_3_out_of_5_at_indices);
+    test_for_all_curves_and_hashes!(test_secret_sharing_3_out_of_5_at_indices);
 
-    fn test_secret_sharing_3_out_of_5_at_indices<E: Curve>() {
+    fn test_secret_sharing_3_out_of_5_at_indices<E: Curve, H: Digest + Clone>() {
         let secret = Scalar::random();
         let parties = [1, 2, 4, 5, 6];
-        let (vss_scheme, secret_shares) = VerifiableSS::<E>::share_at_indices(
+        let (vss_scheme, secret_shares) = VerifiableSS::<E, H>::share_at_indices(
             3,
             5,
             &secret,
@@ -313,12 +328,12 @@ mod tests {
         assert_eq!(secret, secret_reconstructed);
     }
 
-    test_for_all_curves!(test_secret_sharing_3_out_of_5);
+    test_for_all_curves_and_hashes!(test_secret_sharing_3_out_of_5);
 
-    fn test_secret_sharing_3_out_of_5<E: Curve>() {
+    fn test_secret_sharing_3_out_of_5<E: Curve, H: Digest + Clone>() {
         let secret = Scalar::random();
 
-        let (vss_scheme, secret_shares) = VerifiableSS::<E>::share(3, 5, &secret);
+        let (vss_scheme, secret_shares) = VerifiableSS::<E, H>::share(3, 5, &secret);
 
         let shares_vec = vec![
             secret_shares[0].clone(),
@@ -345,11 +360,11 @@ mod tests {
 
         // test map (t,n) - (t',t')
         let s = &vec![0, 1, 2, 3, 4];
-        let l0 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
-        let l1 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 1, s);
-        let l2 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 2, s);
-        let l3 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 3, s);
-        let l4 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 4, s);
+        let l0 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
+        let l1 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 1, s);
+        let l2 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 2, s);
+        let l3 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 3, s);
+        let l4 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 4, s);
         let w = l0 * &secret_shares[0]
             + l1 * &secret_shares[1]
             + l2 * &secret_shares[2]
@@ -358,12 +373,12 @@ mod tests {
         assert_eq!(w, secret_reconstructed);
     }
 
-    test_for_all_curves!(test_secret_sharing_3_out_of_7);
+    test_for_all_curves_and_hashes!(test_secret_sharing_3_out_of_7);
 
-    fn test_secret_sharing_3_out_of_7<E: Curve>() {
+    fn test_secret_sharing_3_out_of_7<E: Curve, H: Digest + Clone>() {
         let secret = Scalar::random();
 
-        let (vss_scheme, secret_shares) = VerifiableSS::<E>::share(3, 7, &secret);
+        let (vss_scheme, secret_shares) = VerifiableSS::<E, H>::share(3, 7, &secret);
 
         let shares_vec = vec![
             secret_shares[0].clone(),
@@ -384,11 +399,11 @@ mod tests {
 
         // test map (t,n) - (t',t')
         let s = &vec![0, 1, 3, 4, 6];
-        let l0 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
-        let l1 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 1, s);
-        let l3 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 3, s);
-        let l4 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 4, s);
-        let l6 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 6, s);
+        let l0 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
+        let l1 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 1, s);
+        let l3 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 3, s);
+        let l4 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 4, s);
+        let l6 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 6, s);
 
         let w = l0 * &secret_shares[0]
             + l1 * &secret_shares[1]
@@ -398,12 +413,12 @@ mod tests {
         assert_eq!(w, secret_reconstructed);
     }
 
-    test_for_all_curves!(test_secret_sharing_1_out_of_2);
+    test_for_all_curves_and_hashes!(test_secret_sharing_1_out_of_2);
 
-    fn test_secret_sharing_1_out_of_2<E: Curve>() {
+    fn test_secret_sharing_1_out_of_2<E: Curve, H: Digest + Clone>() {
         let secret = Scalar::random();
 
-        let (vss_scheme, secret_shares) = VerifiableSS::<E>::share(1, 2, &secret);
+        let (vss_scheme, secret_shares) = VerifiableSS::<E, H>::share(1, 2, &secret);
 
         let shares_vec = vec![secret_shares[0].clone(), secret_shares[1].clone()];
 
@@ -419,23 +434,23 @@ mod tests {
 
         // test map (t,n) - (t',t')
         let s = &vec![0, 1];
-        let l0 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
-        let l1 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 1, s);
+        let l0 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
+        let l1 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 1, s);
         let w = l0 * &secret_shares[0] + l1 * &secret_shares[1];
         assert_eq!(w, secret_reconstructed);
     }
 
-    test_for_all_curves!(test_secret_sharing_1_out_of_3);
+    test_for_all_curves_and_hashes!(test_secret_sharing_1_out_of_3);
 
-    fn test_secret_sharing_1_out_of_3<E: Curve>() {
+    fn test_secret_sharing_1_out_of_3<E: Curve, H: Digest + Clone>() {
         let secret = Scalar::random();
 
-        let (vss_scheme, secret_shares) = VerifiableSS::<E>::share(1, 3, &secret);
+        let (vss_scheme, secret_shares) = VerifiableSS::<E, H>::share(1, 3, &secret);
 
         let shares_vec = vec![secret_shares[0].clone(), secret_shares[1].clone()];
 
         // test commitment to point and sum of commitments
-        let (vss_scheme2, secret_shares2) = VerifiableSS::<E>::share(1, 3, &secret);
+        let (vss_scheme2, secret_shares2) = VerifiableSS::<E, H>::share(1, 3, &secret);
         let sum = &secret_shares[0] + &secret_shares2[0];
         let point_comm1 = vss_scheme.get_point_commitment(1);
         let point_comm2 = vss_scheme.get_point_commitment(2);
@@ -459,19 +474,19 @@ mod tests {
 
         // test map (t,n) - (t',t')
         let s = &vec![0, 2];
-        let l0 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
-        let l2 = VerifiableSS::<E>::map_share_to_new_params(&vss_scheme.parameters, 2, s);
+        let l0 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 0, s);
+        let l2 = VerifiableSS::<E, H>::map_share_to_new_params(&vss_scheme.parameters, 2, s);
 
         let w = l0 * &secret_shares[0] + l2 * &secret_shares[2];
         assert_eq!(w, secret_reconstructed);
     }
 
-    test_for_all_curves!(test_secret_resharing);
+    test_for_all_curves_and_hashes!(test_secret_resharing);
 
-    fn test_secret_resharing<E: Curve>() {
+    fn test_secret_resharing<E: Curve, H: Digest + Clone>() {
         let secret = Scalar::random();
 
-        let (vss_scheme, secret_shares) = VerifiableSS::<E>::share(1, 3, &secret);
+        let (vss_scheme, secret_shares) = VerifiableSS::<E, H>::share(1, 3, &secret);
         let (new_vss_scheme, zero_secret_shares) = vss_scheme.reshare();
 
         let new_share_party_1 = &secret_shares[0] + &zero_secret_shares[0];


### PR DESCRIPTION
Currently the VSS Feldman primitive in Curv is vulnerable to n-t+1 attack, where there are n-t+1 malicious collaborators that can take over the protocol if one of them publishes 0-th polynomial coefficient commitment that is equal to s*G - \sum (Honest Participants' 0-th coefficient commitments). If there are n-t+1 adversaries, then the attackers can solve the system of linear equations and alter their polynomial coefficient commitments so that the honest participants don't notice that the attacker's 0-th coefficient commitment is poisoned. To defend from this attack I've added a proof of knowledge of the dlog of the 0-th commitment.