### PR TITLE
feat: upgrade RustCrypto related crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ crate-type = ["lib"]
 [dependencies]
 cryptoxide = "0.1.2"
 curve25519-dalek = "3"
-digest = "0.9"
+digest = "0.10"
 generic-array = "0.14"
 typenum = "1.13"
 ff-zeroize = "0.6.3"
 hex = { version = "0.4", features = ["serde"] }
-hmac = "0.11"
+hmac = "0.12"
 thiserror = "1"
 lazy_static = "1.4"
 num-traits = "0.2"
@@ -33,8 +33,8 @@ rand_legacy = { package = "rand", version = "0.6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
-sha2 = "0.9"
-sha3 = "0.9"
+sha2 = "0.10"
+sha3 = "0.10"
 old_sha2 = { package = "sha2", version = "0.8" }
 zeroize = "1"
 merkle-cbt = "0.3"
@@ -47,7 +47,7 @@ version = "0.20"
 features = ["serde", "rand-std", "global-context"]
 
 [dependencies.p256]
-version = "0.11.1"
+version = "0.12"
 features = ["ecdsa", "ecdsa-core"]
 
 [dev-dependencies]
@@ -56,7 +56,6 @@ serde_json = "1"
 paste = "1.0.2"
 proptest = "0.10"
 proptest-derive = "0.2"
-blake2 = "0.9"
 
 [features]
 default = ["rust-gmp-kzen"]

--- a/examples/diffie_hellman_key_exchange.rs
+++ b/examples/diffie_hellman_key_exchange.rs
@@ -38,7 +38,7 @@ fn main() {
         Some("bls12_381_1") => ecdh::<Bls12_381_1>(),
         Some("bls12_381_2") => ecdh::<Bls12_381_2>(),
         Some("p256") => ecdh::<Secp256r1>(),
-        Some(unknown_curve) => eprintln!("Unknown curve: {}", unknown_curve),
+        Some(unknown_curve) => eprintln!("Unknown curve: {unknown_curve}"),
         None => eprintln!("Missing curve name"),
     }
 }

--- a/examples/pedersen_commitment.rs
+++ b/examples/pedersen_commitment.rs
@@ -24,8 +24,7 @@ pub fn ped_com<E: Curve>(message: &BigInt) {
     );
 
     println!(
-        "\ncreated commitment with user defined randomness \n\n blinding_factor {} \n commitment: {:#?}",
-        blinding_factor, com
+        "\ncreated commitment with user defined randomness \n\n blinding_factor {blinding_factor} \n commitment: {com:#?}",
     );
 }
 
@@ -40,7 +39,7 @@ fn main() {
         Some("bls12_381_1") => ped_com::<Bls12_381_1>(&message_bn),
         Some("bls12_381_2") => ped_com::<Bls12_381_2>(&message_bn),
         Some("p256") => ped_com::<Secp256r1>(&message_bn),
-        Some(unknown_curve) => eprintln!("Unknown curve: {}", unknown_curve),
+        Some(unknown_curve) => eprintln!("Unknown curve: {unknown_curve}"),
         None => eprintln!("Missing curve name"),
     }
 }

--- a/examples/proof_of_knowledge_of_dlog.rs
+++ b/examples/proof_of_knowledge_of_dlog.rs
@@ -27,7 +27,7 @@ fn main() {
         Some("bls12_381_1") => dlog_proof::<Bls12_381_1>(),
         Some("bls12_381_2") => dlog_proof::<Bls12_381_2>(),
         Some("p256") => dlog_proof::<Secp256r1>(),
-        Some(unknown_curve) => eprintln!("Unknown curve: {}", unknown_curve),
+        Some(unknown_curve) => eprintln!("Unknown curve: {unknown_curve}"),
         None => eprintln!("Missing curve name"),
     }
 }

--- a/examples/verifiable_secret_sharing.rs
+++ b/examples/verifiable_secret_sharing.rs
@@ -66,7 +66,7 @@ fn main() {
         Some("bls12_381_1") => secret_sharing_3_out_of_5::<Bls12_381_1>(),
         Some("bls12_381_2") => secret_sharing_3_out_of_5::<Bls12_381_2>(),
         Some("p256") => secret_sharing_3_out_of_5::<Secp256r1>(),
-        Some(unknown_curve) => eprintln!("Unknown curve: {}", unknown_curve),
+        Some(unknown_curve) => eprintln!("Unknown curve: {unknown_curve}"),
         None => eprintln!("Missing curve name"),
     }
 }

--- a/src/arithmetic/errors.rs
+++ b/src/arithmetic/errors.rs
@@ -20,7 +20,7 @@ impl fmt::Display for ParseBigIntError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.reason {
             #[cfg(feature = "rust-gmp-kzen")]
-            ParseErrorReason::Gmp(reason) => write!(f, "{}", reason),
+            ParseErrorReason::Gmp(reason) => write!(f, "{reason}"),
             #[cfg(feature = "num-bigint")]
             ParseErrorReason::NumBigint => {
                 write!(f, "invalid {}-based number representation", self.radix)

--- a/src/arithmetic/mod.rs
+++ b/src/arithmetic/mod.rs
@@ -131,7 +131,7 @@ mod test {
 
         for (i, expect) in expectations.into_iter().enumerate() {
             let i = 7 - i - 1;
-            assert_eq!(n.test_bit(i), expect, "testing {} bit", i)
+            assert_eq!(n.test_bit(i), expect, "testing {i} bit")
         }
     }
 
@@ -285,7 +285,7 @@ mod test {
                     expected = expected.wrapping_mul(n);
                 }
             }
-            assert_eq!(actual, BigInt::from(expected), "{} [{:?}] {}", was, op, n)
+            assert_eq!(actual, BigInt::from(expected), "{was} [{op:?}] {n}")
         }
     }
 

--- a/src/cryptographic_primitives/commitments/hash_commitment.rs
+++ b/src/cryptographic_primitives/commitments/hash_commitment.rs
@@ -109,9 +109,9 @@ mod tests {
             &BigInt::zero(),
         );
         let message2 = message.to_bytes();
-        digest.update(&message2);
+        digest.update(message2);
         let bytes_blinding_factor = &BigInt::zero().to_bytes();
-        digest.update(&bytes_blinding_factor);
+        digest.update(bytes_blinding_factor);
         let hash_result = BigInt::from_bytes(digest.finalize().as_ref());
         assert_eq!(&commitment, &hash_result);
     }

--- a/src/cryptographic_primitives/commitments/hash_commitment.rs
+++ b/src/cryptographic_primitives/commitments/hash_commitment.rs
@@ -27,8 +27,8 @@ impl<H: Digest + Clone> Commitment<BigInt> for HashCommitment<H> {
         blinding_factor: &BigInt,
     ) -> BigInt {
         let digest_result = H::new()
-            .chain(message.to_bytes())
-            .chain(blinding_factor.to_bytes())
+            .chain_update(message.to_bytes())
+            .chain_update(blinding_factor.to_bytes())
             .finalize();
         BigInt::from_bytes(digest_result.as_ref())
     }
@@ -47,11 +47,11 @@ mod tests {
     use super::SECURITY_BITS;
     use crate::arithmetic::traits::*;
     use crate::{test_for_all_hashes, BigInt};
-    use digest::Digest;
+    use digest::{Digest, OutputSizeUser};
 
     test_for_all_hashes!(test_bit_length_create_commitment);
     fn test_bit_length_create_commitment<H: Digest + Clone>() {
-        let hex_len = H::output_size() * 8;
+        let hex_len = <H as OutputSizeUser>::output_size() * 8;
         let mut ctr_commit_len = 0;
         let mut ctr_blind_len = 0;
         let sample_size = 10_000;
@@ -77,7 +77,7 @@ mod tests {
 
     test_for_all_hashes!(test_bit_length_create_commitment_with_user_defined_randomness);
     fn test_bit_length_create_commitment_with_user_defined_randomness<H: Digest + Clone>() {
-        let sec_bits = H::output_size() * 8;
+        let sec_bits = <H as OutputSizeUser>::output_size() * 8;
         let message = BigInt::sample(sec_bits);
         let (_commitment, blind_factor) = HashCommitment::<H>::create_commitment(&message);
         let commitment2 = HashCommitment::<H>::create_commitment_with_user_defined_randomness(

--- a/src/cryptographic_primitives/hashing/ext.rs
+++ b/src/cryptographic_primitives/hashing/ext.rs
@@ -88,7 +88,7 @@ where
     D: Digest + Clone,
 {
     fn input_bigint(&mut self, n: &BigInt) {
-        self.update(&n.to_bytes())
+        self.update(n.to_bytes())
     }
 
     fn input_point<E: Curve>(&mut self, point: &Point<E>) {
@@ -96,7 +96,7 @@ where
     }
 
     fn input_scalar<E: Curve>(&mut self, scalar: &Scalar<E>) {
-        self.update(&scalar.to_bigint().to_bytes())
+        self.update(scalar.to_bigint().to_bytes())
     }
 
     fn result_bigint(self) -> BigInt {

--- a/src/cryptographic_primitives/hashing/merkle_tree.rs
+++ b/src/cryptographic_primitives/hashing/merkle_tree.rs
@@ -85,7 +85,7 @@ where
     type Item = Output<D>;
 
     fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item {
-        D::new().chain(left).chain(right).finalize()
+        D::new().chain_update(left).chain_update(right).finalize()
     }
 }
 

--- a/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_enc.rs
+++ b/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_enc.rs
@@ -175,6 +175,6 @@ mod tests {
             E,
         };
         let proof = HomoELGamalProof::<E, H>::prove(&witness, &delta);
-        assert!(!proof.verify(&delta).is_ok());
+        assert!(proof.verify(&delta).is_err());
     }
 }

--- a/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_encryption_of_dlog.rs
+++ b/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_encryption_of_dlog.rs
@@ -144,6 +144,6 @@ mod tests {
             E,
         };
         let proof = HomoELGamalDlogProof::<E, H>::prove(&witness, &delta);
-        assert!(!proof.verify(&delta).is_ok());
+        assert!(proof.verify(&delta).is_err());
     }
 }

--- a/src/cryptographic_primitives/proofs/sigma_ec_ddh.rs
+++ b/src/cryptographic_primitives/proofs/sigma_ec_ddh.rs
@@ -131,6 +131,6 @@ mod tests {
         };
         let w = ECDDHWitness { x };
         let proof = ECDDHProof::<E, H>::prove(&w, &delta);
-        assert!(!proof.verify(&delta).is_ok());
+        assert!(proof.verify(&delta).is_err());
     }
 }

--- a/src/elliptic/curves/bls12_381/g1.rs
+++ b/src/elliptic/curves/bls12_381/g1.rs
@@ -298,7 +298,7 @@ mod tests {
         // Print in uncompressed form
         use pairing_plus::EncodedPoint;
         let point_uncompressed = G1Uncompressed::from_affine(point);
-        println!("Uncompressed base_point2: {:?}", point_uncompressed);
+        println!("Uncompressed base_point2: {point_uncompressed:?}");
 
         // Check that ECPoint::base_point2() returns generated point
         let base_point2: &GE1 = ECPoint::base_point2();

--- a/src/elliptic/curves/bls12_381/g2.rs
+++ b/src/elliptic/curves/bls12_381/g2.rs
@@ -303,7 +303,7 @@ mod tests {
 
         // Print in uncompressed form
         let point_uncompressed = G2Uncompressed::from_affine(point);
-        println!("Uncompressed base_point2: {:?}", point_uncompressed);
+        println!("Uncompressed base_point2: {point_uncompressed:?}");
 
         // Check that ECPoint::base_point2() returns generated point
         let base_point2: &G2Point = ECPoint::base_point2();

--- a/src/elliptic/curves/curve_ristretto.rs
+++ b/src/elliptic/curves/curve_ristretto.rs
@@ -36,7 +36,7 @@ lazy_static::lazy_static! {
 
     static ref BASE_POINT2: RistrettoPoint = {
         let g = RistrettoPoint::generator();
-        let hash = Sha256::digest(g.serialize_compressed().as_ref());
+        let hash = Sha256::digest(&g.serialize_compressed());
         RistrettoPoint {
             purpose: "base_point2",
             ge: RistrettoPoint::deserialize(&hash).unwrap().ge,

--- a/src/elliptic/curves/curve_ristretto.rs
+++ b/src/elliptic/curves/curve_ristretto.rs
@@ -36,7 +36,7 @@ lazy_static::lazy_static! {
 
     static ref BASE_POINT2: RistrettoPoint = {
         let g = RistrettoPoint::generator();
-        let hash = Sha256::digest(&g.serialize_compressed());
+        let hash = Sha256::digest(g.serialize_compressed());
         RistrettoPoint {
             purpose: "base_point2",
             ge: RistrettoPoint::deserialize(&hash).unwrap().ge,

--- a/src/elliptic/curves/ed25519.rs
+++ b/src/elliptic/curves/ed25519.rs
@@ -50,8 +50,8 @@ lazy_static::lazy_static! {
 
     static ref BASE_POINT2: Ed25519Point = {
         let bytes = GENERATOR.serialize_compressed();
-        let hashed = sha2::Sha256::digest(&bytes);
-        let hashed_twice = sha2::Sha256::digest(&hashed);
+        let hashed = sha2::Sha256::digest(bytes);
+        let hashed_twice = sha2::Sha256::digest(hashed);
         let p = Ed25519Point::deserialize(&hashed_twice).unwrap();
         let eight = Ed25519Scalar::from_bigint(&BigInt::from(8));
         Ed25519Point {

--- a/src/elliptic/curves/ed25519.rs
+++ b/src/elliptic/curves/ed25519.rs
@@ -50,7 +50,7 @@ lazy_static::lazy_static! {
 
     static ref BASE_POINT2: Ed25519Point = {
         let bytes = GENERATOR.serialize_compressed();
-        let hashed = sha2::Sha256::digest(bytes.as_ref());
+        let hashed = sha2::Sha256::digest(&bytes);
         let hashed_twice = sha2::Sha256::digest(&hashed);
         let p = Ed25519Point::deserialize(&hashed_twice).unwrap();
         let eight = Ed25519Scalar::from_bigint(&BigInt::from(8));

--- a/src/elliptic/curves/p256.rs
+++ b/src/elliptic/curves/p256.rs
@@ -410,8 +410,8 @@ mod tests {
         let base_point2 = GE::base_point2();
 
         let g = GE::generator();
-        let hash = Sha256::digest(&g.serialize_compressed());
-        let hash = Sha256::digest(&hash);
+        let hash = Sha256::digest(g.serialize_compressed());
+        let hash = Sha256::digest(hash);
 
         assert_eq!(BigInt::from_bytes(&hash), base_point2.x_coord().unwrap());
 

--- a/src/elliptic/curves/p256.rs
+++ b/src/elliptic/curves/p256.rs
@@ -410,7 +410,7 @@ mod tests {
         let base_point2 = GE::base_point2();
 
         let g = GE::generator();
-        let hash = Sha256::digest(g.serialize_compressed().as_ref());
+        let hash = Sha256::digest(&g.serialize_compressed());
         let hash = Sha256::digest(&hash);
 
         assert_eq!(BigInt::from_bytes(&hash), base_point2.x_coord().unwrap());

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -582,9 +582,9 @@ mod test {
         let base_point2 = GE::base_point2();
 
         let g = GE::generator();
-        let hash = Sha256::digest(&g.serialize_compressed());
-        let hash = Sha256::digest(&hash);
-        let hash = Sha256::digest(&hash);
+        let hash = Sha256::digest(g.serialize_compressed());
+        let hash = Sha256::digest(hash);
+        let hash = Sha256::digest(hash);
 
         assert_eq!(BigInt::from_bytes(&hash), base_point2.x_coord().unwrap());
 

--- a/src/elliptic/curves/wrappers/serde_support.rs
+++ b/src/elliptic/curves/wrappers/serde_support.rs
@@ -171,7 +171,7 @@ impl<'de, E: Curve> Deserialize<'de> for PointFromBytes<E> {
             where
                 Err: Error,
             {
-                Point::from_bytes(v).map_err(|e| Err::custom(format!("invalid point: {}", e)))
+                Point::from_bytes(v).map_err(|e| Err::custom(format!("invalid point: {e}")))
             }
 
             // serde_json serializes bytes as a sequence of u8, so we need to support this format too
@@ -200,20 +200,19 @@ impl<'de, E: Curve> Deserialize<'de> for PointFromBytes<E> {
                     if seq.next_element::<IgnoredAny>()?.is_some() {
                         return Err(A::Error::invalid_length(
                             seq_len_hint.unwrap_or(seq_len + 1),
-                            &format!("either {} or {} bytes", compressed_len, uncompressed_len)
+                            &format!("either {compressed_len} or {uncompressed_len} bytes")
                                 .as_str(),
                         ));
                     }
                 } else if seq_len != compressed_len {
                     return Err(A::Error::invalid_length(
                         seq_len_hint.unwrap_or(seq_len),
-                        &format!("either {} or {} bytes", compressed_len, uncompressed_len)
-                            .as_str(),
+                        &format!("either {compressed_len} or {uncompressed_len} bytes").as_str(),
                     ));
                 }
 
                 Point::from_bytes(&buffer.as_slice()[..seq_len])
-                    .map_err(|e| A::Error::custom(format!("invalid point: {}", e)))
+                    .map_err(|e| A::Error::custom(format!("invalid point: {e}")))
             }
 
             fn visit_str<Err>(self, v: &str) -> Result<Self::Value, Err>
@@ -230,12 +229,12 @@ impl<'de, E: Curve> Deserialize<'de> for PointFromBytes<E> {
                     hex::decode_to_slice(v, &mut buffer)
                         .map_err(|_| Err::custom("malformed hex encoding"))?;
                     Point::from_bytes(&buffer)
-                        .map_err(|e| Err::custom(format!("invalid point: {}", e)))?
+                        .map_err(|e| Err::custom(format!("invalid point: {e}")))?
                 } else if compressed_len * 2 == v.len() {
                     hex::decode_to_slice(v, &mut buffer[..compressed_len])
                         .map_err(|_| Err::custom("malformed hex encoding"))?;
                     Point::from_bytes(&buffer[..compressed_len])
-                        .map_err(|e| Err::custom(format!("invalid point: {}", e)))?
+                        .map_err(|e| Err::custom(format!("invalid point: {e}")))?
                 } else {
                     return Err(Err::custom("invalid point"));
                 };
@@ -390,7 +389,7 @@ impl<'de, E: Curve> Deserialize<'de> for ScalarFromBytes<E> {
                         None => {
                             return Err(A::Error::invalid_length(
                                 i,
-                                &format!("{} bytes", expected_len).as_str(),
+                                &format!("{expected_len} bytes").as_str(),
                             ))
                         }
                     };
@@ -400,7 +399,7 @@ impl<'de, E: Curve> Deserialize<'de> for ScalarFromBytes<E> {
                 if seq.next_element::<IgnoredAny>()?.is_some() {
                     return Err(A::Error::invalid_length(
                         seq_len_hint.unwrap_or(expected_len + 1),
-                        &format!("{} bytes", expected_len).as_str(),
+                        &format!("{expected_len} bytes").as_str(),
                     ));
                 }
 
@@ -461,7 +460,7 @@ mod serde_tests {
     fn serializes_deserializes_point<E: Curve>() {
         let random_point = Point::<E>::generator() * Scalar::random();
         for point in [Point::zero(), random_point] {
-            println!("Point: {:?}", point);
+            println!("Point: {point:?}");
             let bytes = point.to_bytes(true).to_vec();
             let tokens = [
                 Struct {
@@ -481,7 +480,7 @@ mod serde_tests {
     test_for_all_curves!(serializes_deserializes_scalar);
     fn serializes_deserializes_scalar<E: Curve>() {
         for scalar in [Scalar::<E>::zero(), Scalar::random()] {
-            println!("Scalar: {:?}", scalar);
+            println!("Scalar: {scalar:?}");
             let bytes = scalar.to_bytes().to_vec();
             let tokens = [
                 Struct {
@@ -502,7 +501,7 @@ mod serde_tests {
     fn deserializes_point_from_seq_of_bytes<E: Curve>() {
         let random_point = Point::<E>::generator() * Scalar::random();
         for point in [Point::zero(), random_point] {
-            println!("Point: {:?}", point);
+            println!("Point: {point:?}");
             let bytes = point.to_bytes(true);
             let mut tokens = vec![
                 Struct {
@@ -525,7 +524,7 @@ mod serde_tests {
     test_for_all_curves!(deserializes_scalar_from_seq_of_bytes);
     fn deserializes_scalar_from_seq_of_bytes<E: Curve>() {
         for scalar in [Scalar::<E>::zero(), Scalar::random()] {
-            println!("Scalar: {:?}", scalar);
+            println!("Scalar: {scalar:?}");
             let bytes = scalar.to_bytes();
             let mut tokens = vec![
                 Struct {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -34,8 +34,6 @@ macro_rules! test_for_all_hashes {
             sha512 = sha2::Sha512,
             sha3_256 = sha3::Sha3_256,
             sha3_512 = sha3::Sha3_512,
-            blake2b = blake2::Blake2b,
-            blake2s = blake2::Blake2s,
         }
     };
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,19 +2,19 @@
 #[macro_export]
 macro_rules! test_for_all_curves {
     (#[should_panic] $fn: ident) => {
-        crate::test_for_all_curves!([#[should_panic]] $fn);
+        $crate::test_for_all_curves!([#[should_panic]] $fn);
     };
     ($fn: ident) => {
-        crate::test_for_all_curves!([] $fn);
+        $crate::test_for_all_curves!([] $fn);
     };
     ([$($attrs:tt)*] $fn: ident) => {
-        crate::test_for_all!{[$($attrs)*] $fn =>
-            secp256k1 = crate::elliptic::curves::Secp256k1,
-            p256 = crate::elliptic::curves::Secp256r1,
-            ed25519 = crate::elliptic::curves::Ed25519,
-            ristretto = crate::elliptic::curves::Ristretto,
-            bls12_381_1 = crate::elliptic::curves::Bls12_381_1,
-            bls12_381_2 = crate::elliptic::curves::Bls12_381_2,
+        $crate::test_for_all!{[$($attrs)*] $fn =>
+            secp256k1 = $crate::elliptic::curves::Secp256k1,
+            p256 = $crate::elliptic::curves::Secp256r1,
+            ed25519 = $crate::elliptic::curves::Ed25519,
+            ristretto = $crate::elliptic::curves::Ristretto,
+            bls12_381_1 = $crate::elliptic::curves::Bls12_381_1,
+            bls12_381_2 = $crate::elliptic::curves::Bls12_381_2,
         }
     };
 }
@@ -23,13 +23,13 @@ macro_rules! test_for_all_curves {
 #[macro_export]
 macro_rules! test_for_all_hashes {
     (#[should_panic] $fn: ident) => {
-        crate::test_for_all_hashes!([#[should_panic]] $fn);
+        $crate::test_for_all_hashes!([#[should_panic]] $fn);
     };
     ($fn: ident) => {
-        crate::test_for_all_hashes!([] $fn);
+        $crate::test_for_all_hashes!([] $fn);
     };
     ([$($attrs:tt)*] $fn: ident) => {
-        crate::test_for_all!{[$($attrs)*] $fn =>
+        $crate::test_for_all!{[$($attrs)*] $fn =>
             sha256 = sha2::Sha256,
             sha512 = sha2::Sha512,
             sha3_256 = sha3::Sha3_256,
@@ -50,7 +50,7 @@ macro_rules! test_for_all {
                 $fn::<$inst>()
             }
         }
-        crate::test_for_all!([$($attrs)*] $fn => $($rest)*);
+        $crate::test_for_all!([$($attrs)*] $fn => $($rest)*);
     };
 }
 
@@ -58,28 +58,28 @@ macro_rules! test_for_all {
 #[macro_export]
 macro_rules! test_for_all_curves_and_hashes {
     (#[should_panic] $fn: ident) => {
-        crate::test_for_all_curves_and_hashes!([#[should_panic]] $fn);
+        $crate::test_for_all_curves_and_hashes!([#[should_panic]] $fn);
     };
     ($fn: ident) => {
-        crate::test_for_all_curves_and_hashes!([] $fn);
+        $crate::test_for_all_curves_and_hashes!([] $fn);
     };
     ([$($attrs:tt)*] $fn: ident) => {
-        crate::test_for_all_curves_and_hashes!{compose: [$($attrs)*] $fn =>
-            secp256k1 = crate::elliptic::curves::Secp256k1,
-            p256 = crate::elliptic::curves::Secp256r1,
-            ed25519 = crate::elliptic::curves::Ed25519,
-            ristretto = crate::elliptic::curves::Ristretto,
-            bls12_381_1 = crate::elliptic::curves::Bls12_381_1,
-            bls12_381_2 = crate::elliptic::curves::Bls12_381_2,
+        $crate::test_for_all_curves_and_hashes!{compose: [$($attrs)*] $fn =>
+            secp256k1 = $crate::elliptic::curves::Secp256k1,
+            p256 = $crate::elliptic::curves::Secp256r1,
+            ed25519 = $crate::elliptic::curves::Ed25519,
+            ristretto = $crate::elliptic::curves::Ristretto,
+            bls12_381_1 = $crate::elliptic::curves::Bls12_381_1,
+            bls12_381_2 = $crate::elliptic::curves::Bls12_381_2,
         }
     };
     (compose: [$($attrs:tt)*] $fn: ident =>) => {};
     (compose: [$($attrs:tt)*] $fn: ident => $inst_name: ident = $inst:path, $($rest: tt)*) => {
-        crate::test_for_all_curves_and_hashes!{private: [$($attrs)*] $fn =>
+        $crate::test_for_all_curves_and_hashes!{private: [$($attrs)*] $fn =>
             $inst_name = $inst | sha256 = sha2::Sha256,
             $inst_name = $inst | sha512 = sha2::Sha512,
         }
-        crate::test_for_all_curves_and_hashes!(compose: [$($attrs)*] $fn => $($rest)*);
+        $crate::test_for_all_curves_and_hashes!(compose: [$($attrs)*] $fn => $($rest)*);
     };
     (private: [$($attrs:tt)*] $fn: ident =>) => {};
     (private: [$($attrs:tt)*] $fn:ident => $inst_name1:ident = $inst1: path | $inst_name2:ident = $inst2:path, $($rest: tt)*) => {
@@ -90,6 +90,6 @@ macro_rules! test_for_all_curves_and_hashes {
                 $fn::<$inst1, $inst2>()
             }
         }
-        crate::test_for_all_curves_and_hashes!(private: [$($attrs)*] $fn => $($rest)*);
+        $crate::test_for_all_curves_and_hashes!(private: [$($attrs)*] $fn => $($rest)*);
     };
 }


### PR DESCRIPTION
Changes
1. upgrade RustCrypto related crates

Notes
1. The latest blake2 implementation doesn't work well with hmac and blake2 has its own MAC support in the crate. It's dropped from the test cases.